### PR TITLE
Upgrade to XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'com.enonic.defaults' version '2.1.6'
-    id 'com.enonic.xp.base' version '3.6.2'
+    id 'com.enonic.xp.base'
 }
 
 repositories {
@@ -12,23 +12,19 @@ repositories {
     xp.enonicRepo()
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-    }
-}
-
 configurations {
     includeLib { transitive = false }
 }
 
 dependencies {
-    compileOnly "com.enonic.xp:script-api:${xpVersion}"
+    compileOnly xplibs.api.script
 
     implementation "com.cronutils:cron-utils:9.2.1"
     includeLib "com.cronutils:cron-utils:9.2.1"
 
-    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testImplementation( "com.enonic.xp:testing:${xpVersion}" ) {
+        exclude group: 'org.slf4j', module: 'slf4j-simple'
+    }
     testImplementation(platform("org.junit:junit-bom:5.13.4"))
     testImplementation(platform("org.mockito:mockito-bom:5.23.0"))
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group = com.enonic.lib
 projectName = lib-cron
-xpVersion=7.0.0
-version=1.1.5-SNAPSHOT
+xpVersion=8.0.0-B4
+version=2.0.0-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName

--- a/src/main/java/com/enonic/lib/cron/context/ContextFactory.java
+++ b/src/main/java/com/enonic/lib/cron/context/ContextFactory.java
@@ -12,6 +12,7 @@ import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.SecurityConstants;
 import com.enonic.xp.security.SecurityService;
+import com.enonic.xp.security.SystemConstants;
 import com.enonic.xp.security.User;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.security.auth.VerifiedUsernameAuthToken;
@@ -97,18 +98,17 @@ public final class ContextFactory
 
     private AuthenticationInfo getAuthenticationInfo( final String username, final String idProvider )
     {
-        final VerifiedUsernameAuthToken token = new VerifiedUsernameAuthToken();
-        token.setUsername( username );
-        token.setIdProvider( idProvider == null ? null : IdProviderKey.from( idProvider ) );
+        final IdProviderKey idProviderKey = idProvider == null ? null : IdProviderKey.from( idProvider );
+        final VerifiedUsernameAuthToken token = new VerifiedUsernameAuthToken( idProviderKey, username );
         return this.securityService.authenticate( token );
     }
 
     private <T> T runAsAuthenticated( final Callable<T> runnable )
     {
-        final AuthenticationInfo authInfo = AuthenticationInfo.create().principals( RoleKeys.AUTHENTICATED ).user( User.ANONYMOUS ).build();
+        final AuthenticationInfo authInfo = AuthenticationInfo.create().principals( RoleKeys.AUTHENTICATED ).user( User.anonymous() ).build();
         return ContextBuilder.from( this.defaultContext ).
             authInfo( authInfo ).
-            repositoryId( SecurityConstants.SECURITY_REPO.getId() ).
+            repositoryId( SystemConstants.SYSTEM_REPO_ID ).
             branch( SecurityConstants.BRANCH_SECURITY ).build().
             callWith( runnable );
     }

--- a/src/test/java/com/enonic/lib/cron/handler/LibCronHandlerTest.java
+++ b/src/test/java/com/enonic/lib/cron/handler/LibCronHandlerTest.java
@@ -6,6 +6,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.enonic.lib.cron.scheduler.JobExecutorService;
+import com.enonic.xp.branch.Branch;
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.security.IdProviderKey;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.SecurityService;
@@ -26,6 +30,8 @@ public class LibCronHandlerTest
 {
     private SecurityService securityService;
 
+    private Context defaultContext;
+
     @BeforeEach
     public void initialize()
         throws Exception
@@ -40,18 +46,24 @@ public class LibCronHandlerTest
         when( jobExecutorService.scheduleWithFixedDelay( any(), anyLong(), anyLong(), any() ) ).thenReturn( mock() );
         when( jobExecutorService.schedule( any(), anyLong(), any() ) ).thenReturn( mock() );
         addService( JobExecutorService.class, jobExecutorService );
+
+        this.defaultContext = ContextBuilder.create()
+            .branch( Branch.from( "draft" ) )
+            .repositoryId( RepositoryId.from( "com.enonic.cms.default" ) )
+            .authInfo( AuthenticationInfo.unAuthenticated() )
+            .build();
     }
 
     @Test
     public void testScheduleWithDelay()
     {
-        runFunction( "/test/LibCronHandlerTest.js", "scheduleWithDelay" );
+        defaultContext.runWith( () -> runFunction( "/test/LibCronHandlerTest.js", "scheduleWithDelay" ) );
     }
 
     @Test
     public void testScheduleWithCron()
     {
-        runFunction( "/test/LibCronHandlerTest.js", "scheduleWithCron" );
+        defaultContext.runWith( () -> runFunction( "/test/LibCronHandlerTest.js", "scheduleWithCron" ) );
     }
 
     @Test
@@ -68,7 +80,7 @@ public class LibCronHandlerTest
 
         when( this.securityService.authenticate( Mockito.isA( AuthenticationToken.class ) ) ).thenReturn( authUser );
 
-        runFunction( "/test/LibCronHandlerTest.js", "scheduleWithContext" );
+        defaultContext.runWith( () -> runFunction( "/test/LibCronHandlerTest.js", "scheduleWithContext" ) );
 
         final ArgumentCaptor<AuthenticationToken> captor = ArgumentCaptor.forClass( AuthenticationToken.class );
         verify( this.securityService ).authenticate( captor.capture() );
@@ -89,7 +101,7 @@ public class LibCronHandlerTest
 
         when( this.securityService.authenticate( Mockito.isA( AuthenticationToken.class ) ) ).thenReturn( authUser );
 
-        runFunction( "/test/LibCronHandlerTest.js", "scheduleWithContextLegacy" );
+        defaultContext.runWith( () -> runFunction( "/test/LibCronHandlerTest.js", "scheduleWithContextLegacy" ) );
 
         final ArgumentCaptor<AuthenticationToken> captor = ArgumentCaptor.forClass( AuthenticationToken.class );
         verify( this.securityService ).authenticate( captor.capture() );
@@ -99,12 +111,12 @@ public class LibCronHandlerTest
     @Test
     public void testUnschedule()
     {
-        runFunction( "/test/LibCronHandlerTest.js", "unschedule" );
+        defaultContext.runWith( () -> runFunction( "/test/LibCronHandlerTest.js", "unschedule" ) );
     }
 
     @Test
     public void testList()
     {
-        runFunction( "/test/LibCronHandlerTest.js", "list" );
+        defaultContext.runWith( () -> runFunction( "/test/LibCronHandlerTest.js", "list" ) );
     }
 }

--- a/src/test/java/com/enonic/lib/cron/model/JobDescriptorMapperTest.java
+++ b/src/test/java/com/enonic/lib/cron/model/JobDescriptorMapperTest.java
@@ -13,8 +13,10 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import com.enonic.lib.cron.mapper.JobDescriptorMapper;
-import com.enonic.xp.context.ContextAccessor;
-import com.enonic.xp.script.serializer.JsonMapGenerator;
+import com.enonic.xp.branch.Branch;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.repository.RepositoryId;
+import com.enonic.xp.testing.serializer.JsonMapGenerator;
 
 public class JobDescriptorMapperTest
 {
@@ -26,7 +28,10 @@ public class JobDescriptorMapperTest
             name( "myJob" ).
             cron( "* * * * *" ).
             applicationKey( "appKey" ).
-            context( ContextAccessor.current() );
+            context( ContextBuilder.create()
+                         .branch( Branch.from( "draft" ) )
+                         .repositoryId( RepositoryId.from( "com.enonic.cms.default" ) )
+                         .build() );
 
         final ScriptEngine engine = new ScriptEngineManager().getEngineByName( "nashorn" );
         builder.script( () -> {

--- a/src/test/resources/test/LibCronHandlerTest.js
+++ b/src/test/resources/test/LibCronHandlerTest.js
@@ -78,6 +78,7 @@ var expectedWithContextJson = {
             user: {
                 type: 'user',
                 key: 'user:system:test-user',
+                displayName: 'test-user',
                 disabled: false,
                 email: 'test-user@example.no',
                 login: 'test-user',


### PR DESCRIPTION
## Summary

Migrates `lib-cron` from XP 7 to the XP 8 beta line.

### Build / dependencies
- `xpVersion` 7.0.0 → 8.0.0-B4
- Project version 1.1.5-SNAPSHOT → 2.0.0-SNAPSHOT (next-major bump for XP 8 compatibility)
- Settings plugin: add `com.enonic.xp.settings` 4.0.0-B1 in `settings.gradle`
- `com.enonic.xp.base` no longer pinned (the settings plugin supplies it); Java 11 toolchain block dropped (toolchain inherited from the plugin)
- `compileOnly script-api` switched to the `xplibs.api.script` catalog alias
- Gradle wrapper bumped to 9.4.1
- The custom `includeLib { transitive = false }` configuration and the `copyLibFiles` Copy task are preserved verbatim — they are how this lib shades `com.cronutils:cron-utils:9.2.1` into the OSGi bundle

### Source / test changes the upgrade forced
- `ContextFactory` updated for XP 8 core-api removals:
  - `VerifiedUsernameAuthToken` is now immutable — switched to the `(IdProviderKey, String)` constructor
  - `User.ANONYMOUS` → `User.anonymous()`
  - `SecurityConstants.SECURITY_REPO.getId()` → `SystemConstants.SYSTEM_REPO_ID` (the security/system repo collapse from #10474)
- Test-side: `JsonMapGenerator` moved from `com.enonic.xp.script.serializer` to `com.enonic.xp.testing.serializer`
- `LibCronHandlerTest` and `JobDescriptorMapperTest` now stand up an explicit default `Context` (branch=`draft`, repo=`com.enonic.cms.default`, `AuthenticationInfo.unAuthenticated()`). XP 8 removed the implicit default repository (#10474), so `ContextAccessor.current()` no longer carries a branch/repo by default
- `LibCronHandlerTest.js` expected JSON now includes `displayName: 'test-user'` because `User.Builder.login(...)` auto-sets `displayName` when none is supplied
- Excluded the transitive `org.slf4j:slf4j-simple` from `com.enonic.xp:testing` so `slf4j-log4j12` wins as the SLF4J binding (otherwise `JobExecutionCommandTest`'s log4j appender mock never fires)

### Not touched
- No descriptor migration (this is a library — no `application.xml`, no `site/`, no admin tools), so `xp8migrator` is N/A
- No runtime / sandbox deploy verification (sandbox is ephemeral on this runner)

## Verification

- `./gradlew clean build` is green on Java 25 with the 9.4.1 wrapper
- The built jar still ships the shaded cron-utils classes:
  ```
  $ unzip -l build/libs/lib-cron-2.0.0-SNAPSHOT.jar | grep cronutils.*\.class | head
  com/cronutils/Function.class
  com/cronutils/StringValidations.class
  com/cronutils/builder/CronBuilder.class
  ...
  ```
- All 26 tests pass

## Test plan

- [x] `./gradlew clean build` green locally on Java 25
- [x] `unzip -l build/libs/lib-cron-2.0.0-SNAPSHOT.jar | grep cronutils` shows shaded classes
- [ ] CI green on the PR

## Follow-ups (after merge of this PR + `2.0.0-SNAPSHOT` published from master)

Several apps still pin the old `lib-cron` and carry `{ exclude group: 'com.enonic.xp' }` (or module-specific variants) on it. Once `lib-cron 2.0.0-SNAPSHOT` is published from `master` they can drop the excludes:

- `app-ai-content-operator` — `exclude group: 'com.enonic.xp', module: 'lib-common'` on lib-cron
- `app-ai-translator` — same
- `app-siteimprove` — `exclude group: 'com.enonic.xp'` on lib-cron
- `app-patchman` — re-grep before queueing (suspected user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)