### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Master is already at `version=2.0.0-SNAPSHOT` in `gradle.properties`, so no version bump needed in this PR.
- Adds `releaseBranch:` block to the `enonic-gradle.yml` workflow listing both `master` and `1.x`, so pushes to either branch are recognized as release-branch builds.
- Companion PR adds the same workflow change on the new `1.x` maintenance branch (cut from post-tag SNAPSHOT commit `feeffd7`, version `1.1.5-SNAPSHOT`).

## Test plan

- [ ] CI on this PR is green.
- [ ] After merge, a push to `master` continues to build cleanly.