### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x` so pushes to `1.x` are recognized as release-branch builds (the action reads the workflow file from the branch being built).

This mirrors the master-side change merged via #270 and is required because the GitHub Action resolves `releaseBranch:` from the workflow file on the branch under build — the master copy alone is not enough for `1.x` builds.

## Test plan

- [ ] CI on `1.x` after merge classifies the branch as a release branch