### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,20 +19,20 @@ configurations {
 dependencies {
     compileOnly xplibs.api.script
 
-    implementation "com.cronutils:cron-utils:9.2.1"
-    includeLib "com.cronutils:cron-utils:9.2.1"
+    implementation libs.cron.utils
+    includeLib libs.cron.utils
 
     testImplementation( "com.enonic.xp:testing:${xpVersion}" ) {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }
-    testImplementation(platform("org.junit:junit-bom:6.0.3"))
-    testImplementation(platform("org.mockito:mockito-bom:5.23.0"))
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.mockito:mockito-junit-jupiter'
-    testImplementation 'org.slf4j:slf4j-log4j12:2.0.17'
-    testImplementation 'org.apache.felix:org.apache.felix.framework:7.0.5'
-    testImplementation 'org.ops4j.pax.tinybundles:tinybundles:4.0.1'
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(platform(libs.mockito.bom))
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.platform.launcher
+    testImplementation libs.mockito.junit.jupiter
+    testImplementation libs.slf4j.log4j12
+    testImplementation libs.felix.framework
+    testImplementation libs.tinybundles
 }
 
 tasks.register('copyLibFiles', Copy) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+cron-utils = "9.2.1"
+felix-framework = "7.0.5"
+junit = "6.0.3"
+mockito = "5.23.0"
+slf4j = "2.0.17"
+tinybundles = "4.0.1"
+
+[libraries]
+cron-utils = { module = "com.cronutils:cron-utils", version.ref = "cron-utils" }
+felix-framework = { module = "org.apache.felix:org.apache.felix.framework", version.ref = "felix-framework" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
+slf4j-log4j12 = { module = "org.slf4j:slf4j-log4j12", version.ref = "slf4j" }
+tinybundles = { module = "org.ops4j.pax.tinybundles:tinybundles", version.ref = "tinybundles" }


### PR DESCRIPTION
Move inline dependency versions in `build.gradle` into `gradle/libs.versions.toml`. Pin-for-pin migration — no version bumps, no plugin or `xplibs` rewrites, `xpVersion` stays in `gradle.properties`.

## Conventions adopted
- `[versions]` and `[libraries]` sorted alphabetically.
- Keys are short, lowercase, hyphen-separated (`http-client`, not `httpClient`).
- BOM-provided artifacts (`junit-jupiter`, `junit-platform-launcher`, `mockito-junit-jupiter`) omit `version.ref`; the BOM dictates them.
- No `[plugins]` block — `com.enonic.defaults` version stays inline in `plugins {}`, matching `app-features`.

## New catalog

```toml
[versions]
cron-utils = "9.2.1"
felix-framework = "7.0.5"
junit = "6.0.3"
mockito = "5.23.0"
slf4j = "2.0.17"
tinybundles = "4.0.1"

[libraries]
cron-utils = { module = "com.cronutils:cron-utils", version.ref = "cron-utils" }
felix-framework = { module = "org.apache.felix:org.apache.felix.framework", version.ref = "felix-framework" }
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
slf4j-log4j12 = { module = "org.slf4j:slf4j-log4j12", version.ref = "slf4j" }
tinybundles = { module = "org.ops4j.pax.tinybundles:tinybundles", version.ref = "tinybundles" }
```

## Verification
- `./gradlew build --refresh-dependencies` green.
- `./gradlew dependencies --configuration runtimeClasspath` and `testRuntimeClasspath` outputs are byte-identical to the pre-migration HEAD (only `BUILD SUCCESSFUL in <time>` differs).