### PR TITLE
Add @enonic-types/lib-cron types package #280

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             1.x

--- a/build.gradle
+++ b/build.gradle
@@ -62,3 +62,15 @@ check.dependsOn jacocoTestReport
 test {
     useJUnitPlatform()
 }
+
+// Assemble the @enonic-types/lib-cron npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,189 @@
+import type { PrincipalKey, User } from "@enonic-types/core";
+
+declare module "/lib/cron" {
+    export interface ScheduleContextUser {
+        /**
+         * User login.
+         */
+        login: string;
+
+        /**
+         * ID provider containing the user.
+         */
+        idProvider?: string;
+
+        /**
+         * @deprecated Use `idProvider` instead.
+         */
+        userStore?: string;
+    }
+
+    export interface ScheduleContext {
+        /**
+         * Repository to execute the callback in.
+         */
+        repository?: string;
+
+        /**
+         * Name of the branch to execute the callback in.
+         */
+        branch?: string;
+
+        /**
+         * Additional principals to execute the callback with.
+         */
+        principals?: PrincipalKey[];
+
+        /**
+         * Additional context attributes.
+         */
+        attributes?: Record<string, unknown>;
+
+        /**
+         * User credentials to execute the callback with.
+         */
+        user?: ScheduleContextUser;
+    }
+
+    export interface ScheduleParams {
+        /**
+         * Unique task name.
+         */
+        name: string;
+
+        /**
+         * Code of the task which should be called.
+         */
+        callback: () => void;
+
+        /**
+         * Cron pattern (see https://en.wikipedia.org/wiki/Cron). Cannot be combined with `fixedDelay` / `delay`.
+         */
+        cron?: string;
+
+        /**
+         * The delay between the termination of one execution and the commencement of the next (in ms). Cannot be combined with `cron`.
+         */
+        fixedDelay?: number;
+
+        /**
+         * The time to delay first execution (in ms). Cannot be combined with `cron`.
+         */
+        delay?: number;
+
+        /**
+         * The number of times the task will be executed. Leave empty for infinite calls.
+         */
+        times?: number;
+
+        /**
+         * Context of the task run.
+         */
+        context?: ScheduleContext;
+    }
+
+    export interface UnscheduleParams {
+        /**
+         * Name of the scheduled task to remove.
+         */
+        name: string;
+    }
+
+    export interface GetParams {
+        /**
+         * Name of the scheduled task to fetch.
+         */
+        name: string;
+    }
+
+    export interface ListParams {
+        /**
+         * Optional glob-style pattern to filter jobs by name.
+         */
+        pattern?: string;
+    }
+
+    export interface JobDescriptorContextAuthInfo {
+        user?: User;
+        principals?: PrincipalKey[];
+    }
+
+    export interface JobDescriptorContext {
+        repository?: string;
+        branch?: string;
+        authInfo?: JobDescriptorContextAuthInfo;
+    }
+
+    export interface JobDescriptor {
+        /**
+         * Name of the scheduled task.
+         */
+        name: string;
+
+        /**
+         * Cron pattern the task was scheduled with, when scheduled by cron.
+         */
+        cron?: string;
+
+        /**
+         * Human-readable description of the cron pattern.
+         */
+        cronDescription?: string;
+
+        /**
+         * The delay between the termination of one execution and the commencement of the next (in ms), when scheduled by delay.
+         */
+        fixedDelay?: number;
+
+        /**
+         * The time to delay first execution (in ms), when scheduled by delay.
+         */
+        delay?: number;
+
+        /**
+         * Key of the application that scheduled the task.
+         */
+        applicationKey: string;
+
+        /**
+         * Context in which the task callback runs.
+         */
+        context?: JobDescriptorContext;
+
+        /**
+         * Time for next execution in ISO 8601 format.
+         */
+        nextExecTime?: string;
+    }
+
+    export interface JobList {
+        jobs: JobDescriptor[];
+    }
+
+    /**
+     * Schedules a task.
+     */
+    export function schedule(params: ScheduleParams): void;
+
+    /**
+     * Unschedules a scheduled task by name and schedules it again with the given parameters.
+     */
+    export function reschedule(params: ScheduleParams): void;
+
+    /**
+     * Unschedules a scheduled task.
+     */
+    export function unschedule(params: UnscheduleParams): void;
+
+    /**
+     * Fetches a scheduled task by name, or `null` if no such task exists.
+     */
+    export function get(params: GetParams): JobDescriptor | null;
+
+    /**
+     * Lists scheduled tasks, optionally filtered by a name pattern.
+     */
+    export function list(params?: ListParams): JobList;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-cron",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP Cron library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-cron",
+    "cron",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-cron#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-cron.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-cron/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Publishes a TypeScript types package for lib-cron (`@enonic-types/lib-cron`) so consumers stop hand-maintaining local ambient declarations for `/lib/cron`.

- `types/index.d.ts` — ambient `declare module "/lib/cron"` with `schedule` / `reschedule` / `unschedule` / `get` / `list` and their param + return shapes (`ScheduleParams`, `ScheduleContext`, `ScheduleContextUser`, `UnscheduleParams`, `GetParams`, `ListParams`, `JobDescriptor`, `JobDescriptorContext`, `JobDescriptorContextAuthInfo`, `JobList`). Imports `PrincipalKey` and `User` from `@enonic-types/core`.
- `types/package.json` — `@enonic-types/lib-cron` manifest, `publishConfig.access: public`, `dependencies: { "@enonic-types/core": "^8.0.0" }`, placeholder `version: "0.0.0"` (substituted at build).
- `build.gradle` — `assembleTypes` Copy task that copies `types/` into `build/types/` and substitutes `project.version` into the placeholder; `jar.dependsOn assembleTypes`.
- `.github/workflows/enonic-gradle.yml` — `npmPublish: true` on the build-and-publish step + top-level `permissions: { id-token: write, contents: write }` for npm OIDC trusted publishing.

Type shapes were seeded from `app-features/src/main/resources/types/cron.d.ts` and cross-checked against `src/main/resources/lib/cron.js` + the Java mappers (`JobDescriptorMapper`, `ContextMapper`, `PrincipalMapper`).

Mirrors the pattern in enonic/lib-mustache#51 (commit d011ea2). Depends on enonic/release-tools#71 (merged).

Closes #280

## Test plan

- [x] `./gradlew build` green locally
- [x] `build/types/` contains `index.d.ts` + `package.json` with `version` substituted to the project version (`2.1.0-SNAPSHOT`)
- [x] `types/index.d.ts` type-checks against `@enonic-types/core` (`tsc --strict` exit 0)
- [ ] CI `Gradle Build` green

_First publish of a brand-new `@enonic-types/lib-cron` may need the npm trusted-publisher / package access configured org-side._

🤖 Generated with [Claude Code](https://claude.com/claude-code)