### PR TITLE
Align docs structure + drop version-history clutter #282

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,6 +1,10 @@
 = Cron library
+:toc: right
 
-image::https://img.shields.io/badge/xp-7.0.0+-blue.svg[role="right"]
+== Introduction
+
+NOTE: Versions 2.x target XP 8+.
+
 To start using this library, add the following into your `build.gradle` file:
 
 [source,groovy]
@@ -47,7 +51,6 @@ The schedule function takes a parameter object with options.
 *** `*user*` (_object_) User credentials.
 **** `*login*` (_string_) User login.
 **** `*idProvider*` (_string_) Id provider containing the user.
-**** `*userStore*` (_string_) Deprecated. Use idProvider instead.
 
 === `Unschedule`
 
@@ -133,7 +136,7 @@ cron.schedule({
         principals: ['role:system.admin'],<3>
         user: {
             login: 'su',
-            userStore: 'system'
+            idProvider: 'system'
         }
     }
 });

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,12 @@
+{
+  "versions": [
+    {
+      "label": "stable",
+      "checkout": "2.x",
+      "latest": true
+    },
+    {
+      "label": "1.x",
+      "checkout": "1.x"
+    }]
+}


### PR DESCRIPTION
Brings `docs/**` in line with the layout used by `enonic/lib-cors`, and drops version-history clutter from the current (XP 8) docs.

## What changed

`docs/index.adoc`
- Add `:toc: right` and an `== Introduction` section, matching the lib-cors template.
- Add `NOTE: Versions 2.x target XP 8+.` at the top.
- Drop the `xp-7.0.0+` shields.io badge — the 2.x line targets XP 8+.
- Drop the `userStore` (`Deprecated`) parameter row and switch the schedule example from `userStore: 'system'` to `idProvider: 'system'`. `userStore` is a pre-XP-6 field name that doesn't belong in current docs (the runtime still accepts it for back-compat, but docs shouldn't advertise it).

`docs/versions.json` (new)
- Adds the standard versions manifest (`stable → 2.x` marked `latest`, plus `1.x`).

`.github/workflows/enonic-docgen.yml`
- No change — it already lists `master`, `2.x`, `1.x`.

## Deliberately kept

- The whole "Fetch / list result shape" section — that's current behavior, not history.
- The empty `params.pattern` option for `list()` — still works at runtime, just undocumented; a separate cleanup.

## Follow-up

- Cherry-pick the clutter-cleanup doc edits to the `2.x` branch in a follow-up PR (this PR touches `master` only).
- `1.x` (XP 7 branch) will be left untouched, as intended.

Closes #282