### PR TITLE
Align docs structure + drop version-history clutter (2.x) #282

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,6 +1,10 @@
 = Cron library
+:toc: right
 
-image::https://img.shields.io/badge/xp-7.0.0+-blue.svg[role="right"]
+== Introduction
+
+NOTE: Versions 2.x target XP 8+.
+
 To start using this library, add the following into your `build.gradle` file:
 
 [source,groovy]
@@ -47,7 +51,6 @@ The schedule function takes a parameter object with options.
 *** `*user*` (_object_) User credentials.
 **** `*login*` (_string_) User login.
 **** `*idProvider*` (_string_) Id provider containing the user.
-**** `*userStore*` (_string_) Deprecated. Use idProvider instead.
 
 === `Unschedule`
 
@@ -133,7 +136,7 @@ cron.schedule({
         principals: ['role:system.admin'],<3>
         user: {
             login: 'su',
-            userStore: 'system'
+            idProvider: 'system'
         }
     }
 });

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,12 @@
+{
+  "versions": [
+    {
+      "label": "stable",
+      "checkout": "2.x",
+      "latest": true
+    },
+    {
+      "label": "1.x",
+      "checkout": "1.x"
+    }]
+}


### PR DESCRIPTION
Cherry-picks the docs-cleanup commit from #283 onto the `2.x` (XP 8 stable) branch, so the developer-portal build for the stable channel picks up the same edits.

Same content as #283:

- `docs/index.adoc`: add `:toc: right` + `== Introduction`, add the `Versions 2.x target XP 8+` NOTE, drop the `xp-7.0.0+` badge, drop the `userStore` (Deprecated) parameter row and the `userStore: 'system'` in the schedule example (switched to `idProvider: 'system'`).
- `docs/versions.json` (new): `stable → 2.x` marked `latest`, plus `1.x`.

`.github/workflows/enonic-docgen.yml` on this branch already lists `master`, `1.x`, `2.x` — no change needed.

The `1.x` (XP 7) branch is intentionally left untouched.

Related: #283 (same edits on `master`). Closes #282 on merge.