### PR TITLE
GraalJS Compatibility  #286

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,6 @@ dependencies {
     testImplementation libs.slf4j.log4j12
     testImplementation libs.felix.framework
     testImplementation libs.tinybundles
-
-    // the GraalJS language implementation: com.enonic.xp:testing carries only the polyglot API
-    testRuntimeOnly libs.graalvm.js
 }
 
 tasks.register('copyLibFiles', Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -67,16 +67,7 @@ test {
 }
 
 // This library is required by applications running on either script engine, so its tests have to
-// pass on both. Delete this once com.enonic.xp.base registers the engine tasks itself
-// (enonic/xp-gradle-plugin#222).
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs the tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+// pass on both. com.enonic.xp.base 4.2.0 registers the GraalJS task from this list.
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     testImplementation libs.slf4j.log4j12
     testImplementation libs.felix.framework
     testImplementation libs.tinybundles
+
+    // the GraalJS language implementation: com.enonic.xp:testing carries only the polyglot API
+    testRuntimeOnly libs.graalvm.js
 }
 
 tasks.register('copyLibFiles', Copy) {
@@ -62,3 +65,18 @@ check.dependsOn jacocoTestReport
 test {
     useJUnitPlatform()
 }
+
+// This library is required by applications running on either script engine, so its tests have to
+// pass on both. Delete this once com.enonic.xp.base registers the engine tasks itself
+// (enonic/xp-gradle-plugin#222).
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs the tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group = com.enonic.lib
 projectName = lib-cron
-xpVersion=8.0.2
+xpVersion=8.1.0-SNAPSHOT
 version=2.1.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 cron-utils = "9.2.1"
 felix-framework = "7.0.5"
+graalvm = "25.0.3"
 junit = "6.1.2"
 mockito = "5.23.0"
 slf4j = "2.0.18"
@@ -9,6 +10,7 @@ tinybundles = "4.0.1"
 [libraries]
 cron-utils = { module = "com.cronutils:cron-utils", version.ref = "cron-utils" }
 felix-framework = { module = "org.apache.felix:org.apache.felix.framework", version.ref = "felix-framework" }
+graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 cron-utils = "9.2.1"
 felix-framework = "7.0.5"
-graalvm = "25.0.3"
 junit = "6.1.2"
 mockito = "5.23.0"
 slf4j = "2.0.18"
@@ -10,7 +9,6 @@ tinybundles = "4.0.1"
 [libraries]
 cron-utils = { module = "com.cronutils:cron-utils", version.ref = "cron-utils" }
 felix-framework = { module = "org.apache.felix:org.apache.felix.framework", version.ref = "felix-framework" }
-graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/java/com/enonic/lib/cron/handler/LibCronHandler.java
+++ b/src/main/java/com/enonic/lib/cron/handler/LibCronHandler.java
@@ -5,7 +5,7 @@ import com.enonic.lib.cron.mapper.JobDescriptorsMapper;
 import com.enonic.lib.cron.model.params.ListJobsParams;
 import com.enonic.lib.cron.model.params.ScheduleParams;
 import com.enonic.lib.cron.provider.CronJobProvider;
-import com.enonic.lib.cron.scheduler.JobExecutorService;
+import com.enonic.lib.cron.scheduler.JobScheduler;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
@@ -21,7 +21,7 @@ public final class LibCronHandler
     {
         this.cronJobProvider =
             new CronJobProvider( context.getBinding( Context.class ).get(), context.getService( SecurityService.class ).get(),
-                                 context.getService( JobExecutorService.class ).get() );
+                                 context.getService( JobScheduler.class ).get() );
     }
 
     public void schedule( final ScheduleParams params )
@@ -53,10 +53,4 @@ public final class LibCronHandler
     {
         return new ListJobsParams();
     }
-
-    public void deactivate()
-    {
-        this.cronJobProvider.deactivate();
-    }
-
 }

--- a/src/main/java/com/enonic/lib/cron/provider/CronJobProvider.java
+++ b/src/main/java/com/enonic/lib/cron/provider/CronJobProvider.java
@@ -8,7 +8,6 @@ import com.enonic.lib.cron.model.JobDescriptor;
 import com.enonic.lib.cron.model.JobDescriptorFactory;
 import com.enonic.lib.cron.model.params.ListJobsParams;
 import com.enonic.lib.cron.model.params.ScheduleParams;
-import com.enonic.lib.cron.scheduler.JobExecutorService;
 import com.enonic.lib.cron.scheduler.JobScheduler;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.security.SecurityService;
@@ -19,10 +18,10 @@ public class CronJobProvider
 
     private final JobScheduler jobScheduler;
 
-    public CronJobProvider( final Context context, final SecurityService securityService, final JobExecutorService jobExecutorService )
+    public CronJobProvider( final Context context, final SecurityService securityService, final JobScheduler jobScheduler )
     {
         this.jobDescriptorFactory = new JobDescriptorFactory( securityService, context );
-        this.jobScheduler = new JobScheduler( jobExecutorService );
+        this.jobScheduler = jobScheduler;
     }
 
     public void schedule( final ScheduleParams params )
@@ -34,11 +33,6 @@ public class CronJobProvider
     public void unschedule( final String jobName )
     {
         jobScheduler.unschedule( jobName );
-    }
-
-    public void deactivate()
-    {
-        this.jobScheduler.deactivate();
     }
 
     public JobDescriptorMapper get( final String jobName )

--- a/src/main/java/com/enonic/lib/cron/scheduler/JobScheduler.java
+++ b/src/main/java/com/enonic/lib/cron/scheduler/JobScheduler.java
@@ -10,11 +10,21 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.enonic.lib.cron.model.JobDescriptor;
 
+/**
+ * The application's single name-keyed job registry. Registered as a bundle-scoped component so
+ * every {@code LibCronHandler} bean — one per script context — shares the same registry: a job
+ * scheduled through one context can be listed, replaced and unscheduled through any other.
+ */
+@Component(service = JobScheduler.class)
 public final class JobScheduler
 {
     private static final Logger LOG = LoggerFactory.getLogger( JobScheduler.class );
@@ -23,13 +33,16 @@ public final class JobScheduler
 
     private final Map<String, RecurringJob> tasks = new LinkedHashMap<>();
 
-    public JobScheduler( final JobExecutorService executorService )
+    @Activate
+    public JobScheduler( @Reference final JobExecutorService executorService )
     {
         this.jobExecutorService = executorService;
     }
 
+    @Deactivate
     public synchronized void deactivate()
     {
+        this.tasks.values().forEach( RecurringJob::cancel );
         this.tasks.clear();
     }
 

--- a/src/test/java/com/enonic/lib/cron/handler/LibCronHandlerTest.java
+++ b/src/test/java/com/enonic/lib/cron/handler/LibCronHandlerTest.java
@@ -6,6 +6,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.enonic.lib.cron.scheduler.JobExecutorService;
+import com.enonic.lib.cron.scheduler.JobScheduler;
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextBuilder;
@@ -45,7 +46,7 @@ public class LibCronHandlerTest
 
         when( jobExecutorService.scheduleWithFixedDelay( any(), anyLong(), anyLong(), any() ) ).thenReturn( mock() );
         when( jobExecutorService.schedule( any(), anyLong(), any() ) ).thenReturn( mock() );
-        addService( JobExecutorService.class, jobExecutorService );
+        addService( JobScheduler.class, new JobScheduler( jobExecutorService ) );
 
         this.defaultContext = ContextBuilder.create()
             .branch( Branch.from( "draft" ) )

--- a/src/test/java/com/enonic/lib/cron/provider/CronJobProviderTest.java
+++ b/src/test/java/com/enonic/lib/cron/provider/CronJobProviderTest.java
@@ -1,0 +1,65 @@
+package com.enonic.lib.cron.provider;
+
+import java.util.concurrent.ScheduledFuture;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.lib.cron.model.params.ScheduleParams;
+import com.enonic.lib.cron.scheduler.JobExecutorService;
+import com.enonic.lib.cron.scheduler.JobScheduler;
+import com.enonic.xp.branch.Branch;
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.repository.RepositoryId;
+import com.enonic.xp.security.SecurityService;
+import com.enonic.xp.security.auth.AuthenticationInfo;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class CronJobProviderTest
+{
+    @Test
+    public void registryIsSharedAcrossProviders()
+    {
+        final ScheduledFuture<?> firstFuture = mock( ScheduledFuture.class );
+        final ScheduledFuture<?> secondFuture = mock( ScheduledFuture.class );
+        final JobExecutorService executorService = mock( JobExecutorService.class );
+        doReturn( firstFuture, secondFuture ).when( executorService ).scheduleWithFixedDelay( any(), anyLong(), anyLong(), any() );
+
+        final JobScheduler jobScheduler = new JobScheduler( executorService );
+
+        final Context context = ContextBuilder.create()
+            .branch( Branch.from( "draft" ) )
+            .repositoryId( RepositoryId.from( "com.enonic.cms.default" ) )
+            .authInfo( AuthenticationInfo.unAuthenticated() )
+            .build();
+        final SecurityService securityService = mock( SecurityService.class );
+
+        // two providers, as two script contexts of the same application create them
+        final CronJobProvider provider1 = new CronJobProvider( context, securityService, jobScheduler );
+        final CronJobProvider provider2 = new CronJobProvider( context, securityService, jobScheduler );
+
+        provider1.schedule( newParams( "myJob" ) );
+        assertNotNull( provider2.get( "myJob" ) );
+
+        // a same-name schedule through another provider replaces the job instead of duplicating it
+        provider2.schedule( newParams( "myJob" ) );
+        verify( firstFuture ).cancel( true );
+
+        provider2.unschedule( "myJob" );
+        verify( secondFuture ).cancel( true );
+        assertNull( provider1.get( "myJob" ) );
+    }
+
+    private static ScheduleParams newParams( final String name )
+    {
+        return new ScheduleParams().setName( name ).setFixedDelay( 100 ).setScript( () -> {
+        } ).setApplicationKey( "myapplication" );
+    }
+}


### PR DESCRIPTION
Fixes #286.

The name-keyed job registry (`JobScheduler` and its `tasks` map) lived inside the per-script-context `LibCronHandler` bean, so an application with several script contexts — the situation on XP 8 with the GraalJS context pool (enonic/xp#12198) — got independent registries feeding one executor: `unschedule`/`get`/`list` missed jobs scheduled through another context, and a same-name `schedule` duplicated the job instead of replacing it.

Changes:
- `JobScheduler` is now an OSGi DS component, one per bundle like `JobExecutorService` already is, taking the executor as a `@Reference`. Its `@Deactivate` cancels the registered jobs before clearing the registry.
- `LibCronHandler` resolves `JobScheduler` as a service in `initialize`, and `CronJobProvider` receives it instead of constructing its own.
- The dead `deactivate()` chain on `LibCronHandler`/`CronJobProvider` is removed — nothing invoked it, and on a shared registry a per-bean deactivate would have wiped every context's jobs. Lifecycle stays with the bundle: on stop/redeploy DS deactivates the scheduler and the executor shuts down, exactly as before.
- New `CronJobProviderTest` verifies the shared-registry semantics across two providers (schedule via one, get/replace/unschedule via the other); `LibCronHandlerTest` registers the scheduler service instead of the raw executor.

No `cron.js` API changes. Verified with `./gradlew test` (all green) and checked that the compiled classes carry the DS annotations for the app build's bnd pass, matching `JobExecutorService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oz9cKabh9NMDhDt164DAM

---
_Generated by [Claude Code](https://claude.ai/code/session_013oz9cKabh9NMDhDt164DAM)_